### PR TITLE
Remove custom entry point

### DIFF
--- a/SmallMediaPlayer/SmallMediaPlayer.vcxproj
+++ b/SmallMediaPlayer/SmallMediaPlayer.vcxproj
@@ -60,7 +60,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies Condition="'$(VisualStudioVersion)'=='11.0'">winmm.lib;strmiids.lib;quartz.lib;comctl32.lib;gdiplus.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(VisualStudioVersion)'&gt;'14.0'">winmm.lib;strmiids.lib;quartz.lib;comctl32.lib;gdiplus.lib;Version.lib;vcruntimed.lib;ucrtd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(VisualStudioVersion)'&gt;'14.0'">winmm.lib;strmiids.lib;quartz.lib;comctl32.lib;gdiplus.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -81,7 +81,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies Condition="'$(VisualStudioVersion)'=='11.0'">winmm.lib;strmiids.lib;quartz.lib;comctl32.lib;gdiplus.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(VisualStudioVersion)'&gt;'14.0'">winmm.lib;strmiids.lib;quartz.lib;comctl32.lib;gdiplus.lib;vcruntime.lib;ucrt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(VisualStudioVersion)'&gt;'14.0'">winmm.lib;strmiids.lib;quartz.lib;comctl32.lib;gdiplus.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/SmallMediaPlayer/main.cpp
+++ b/SmallMediaPlayer/main.cpp
@@ -7,7 +7,6 @@
 
 #pragma comment(linker,"/MERGE:.rdata=.text")
 #pragma comment(linker,"/SECTION:.text,EWR")
-#pragma comment(linker,"/ENTRY:New_WinMain")
 
 #include <Windows.h>
 
@@ -27,7 +26,7 @@ extern void LoadSettings();
 extern void Init_ProgramFileName();
 
 // Entry point
-void New_WinMain(void){
+int APIENTRY WinMain(HINSTANCE hInst, HINSTANCE hInstPrev, PSTR pstrCmdLine, int nCmdShow){
 
     EnsureSingleInstance();
     Init_ProgramFileName();


### PR DESCRIPTION
Small Media Player historically had custom entry point to remove CRT initialization code for the smaller binary size.
However, it only saves ~200 bytes, so it is not needed now that whole binary is above 76 KB