### PR TITLE
Update CI to VS 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   ci:
 
-    runs-on: windows-2022
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,13 @@ on:
 jobs:
   ci:
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v1
     - name: Build with MSBuild
       run: |
-        & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe"
+        & "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe"
     - name: Test
       run: |
-        Set-Location -Path .\Debug; & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\vstest.console.exe" SmallMediaPlayer_Tests.dll /TestCaseFilter:"Owner!=GUI"
+        Set-Location -Path .\Debug; & "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\TestPlatform\vstest.console.exe" SmallMediaPlayer_Tests.dll /TestCaseFilter:"Owner!=GUI"


### PR DESCRIPTION
https://github.com/actions/virtual-environments/issues/4856

> This change will be rolled out over a period of several weeks beginning on January, 17. We plan to complete the migration by March, 6.